### PR TITLE
[commands] Update disparse usage throughout all commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.release>11</maven.compiler.release>
-    
+
     <junit.version>5.6.0</junit.version>
-    <disparse.version>master-82662a9-1</disparse.version>
+    <disparse.version>0.1.5</disparse.version>
     <jda.version>4.1.1_116</jda.version>
     <log4j.version>2.13.1</log4j.version>
     <postgres.driver.version>42.2.11</postgres.driver.version>
@@ -25,7 +25,7 @@
     <flyway.version>6.3.1</flyway.version>
     <hikari.version>3.4.2</hikari.version>
   </properties>
-  
+
   <repositories>
     <repository>
       <id>jcenter</id>

--- a/src/main/java/uk/co/markg/bertrand/command/About.java
+++ b/src/main/java/uk/co/markg/bertrand/command/About.java
@@ -1,5 +1,7 @@
 package uk.co.markg.bertrand.command;
 
+import disparse.discord.jda.DiscordRequest;
+import disparse.discord.jda.DiscordResponse;
 import disparse.parser.reflection.CommandHandler;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -8,15 +10,15 @@ import java.awt.Color;
 public class About {
 
   @CommandHandler(commandName = "about", description = "Displays info about the bot")
-  public static void execute(MessageReceivedEvent event) {
+  public static DiscordResponse execute(DiscordRequest request) {
     EmbedBuilder eb = new EmbedBuilder();
     eb.setTitle("Mimic Bot");
     eb.setDescription("Mimic is a bot that generates messages using markov chains based on user messages. "
         + "Opting in will tell mimic to read the last 50,000 messages per configured channel and save your messages. "
         + "It will then read any new valid messages sent in those channels.");
-    eb.setThumbnail(event.getJDA().getSelfUser().getAvatarUrl());
+    eb.setThumbnail(request.getEvent().getJDA().getSelfUser().getAvatarUrl());
     eb.addField("Source", "https://github.com/Toby-Larone/bertrand", false);
     eb.setColor(Color.decode("#eb7701"));
-    event.getChannel().sendMessage(eb.build()).queue();
+    return DiscordResponse.of(eb);
   }
 }

--- a/src/main/java/uk/co/markg/bertrand/command/AddChannels.java
+++ b/src/main/java/uk/co/markg/bertrand/command/AddChannels.java
@@ -2,6 +2,9 @@ package uk.co.markg.bertrand.command;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import disparse.discord.jda.DiscordRequest;
+import disparse.parser.reflection.Populate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import disparse.parser.reflection.CommandHandler;
@@ -34,38 +37,31 @@ public class AddChannels {
 
   /**
    * Constructs a new channel command
-   * 
-   * @param event       The discord message event that triggered the command
+   *
+   * @param request     The discord request dispatched to this command
    * @param req         The parsed flags passed with the command
-   * @param channelRepo The channel repository
-   * @param userRepo    The user repository
-   * @param args        The arguments passed with the command. Should be a list of channel ids
-   */
-  public AddChannels(MessageReceivedEvent event, ChannelRequest req, ChannelRepository channelRepo,
-      UserRepository userRepo, List<String> args) {
-    this.event = event;
-    this.req = req;
-    this.channelRepo = channelRepo;
-    this.userRepo = userRepo;
-    this.args = args;
-  }
-
-  /**
-   * Method held by Disparse to begin command execution
-   * 
-   * @param event       The message event from discord that triggered the command
-   * @param req         The command request flags
    * @param channelRepo The {@link uk.co.markg.bertrand.database.ChannelRepository
    *                    ChannelRepository} instance
    * @param userRepo    The {@link uk.co.markg.bertrand.database.UserRepository UserRepository}
    *                    instance
-   * @param args        A list of parsed command arguments. Should be a list of channel ids
+   */
+  @Populate
+  public AddChannels(DiscordRequest request, ChannelRequest req, ChannelRepository channelRepo,
+                     UserRepository userRepo) {
+    this.event = request.getEvent();
+    this.req = req;
+    this.channelRepo = channelRepo;
+    this.userRepo = userRepo;
+    this.args = request.getArgs();
+  }
+
+  /**
+   * Method held by Disparse to begin command execution
    */
   @CommandHandler(commandName = "channels.add",
       description = "Add channels. Defaults to read access only.", roles = "staff")
-  public static void executeAdd(MessageReceivedEvent event, ChannelRequest req,
-      ChannelRepository channelRepo, UserRepository userRepo, List<String> args) {
-    new AddChannels(event, req, channelRepo, userRepo, args).execute();
+  public void executeAdd() {
+    this.execute();
   }
 
   /**
@@ -80,7 +76,7 @@ public class AddChannels {
   /**
    * Takes all channelids passed in and adds them to the database. Collects user message history of
    * all users for each channel
-   * 
+   *
    * @return The response message to send back to the channel
    */
   private String addChannels() {
@@ -104,7 +100,7 @@ public class AddChannels {
   /**
    * Collect channel history for the specificed {@link net.dv8tion.jda.api.entities.TextChannel
    * TextChannel} for all users in the database
-   * 
+   *
    * @param channel The target channel
    */
   private void retrieveChannelHistory(TextChannel channel) {

--- a/src/main/java/uk/co/markg/bertrand/command/ListChannels.java
+++ b/src/main/java/uk/co/markg/bertrand/command/ListChannels.java
@@ -2,7 +2,10 @@ package uk.co.markg.bertrand.command;
 
 import java.awt.Color;
 import java.util.List;
+
+import disparse.discord.jda.DiscordRequest;
 import disparse.parser.reflection.CommandHandler;
+import disparse.parser.reflection.Populate;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -13,21 +16,23 @@ public class ListChannels {
   private MessageReceivedEvent event;
   private ChannelRepository channelRepo;
 
-  public ListChannels(MessageReceivedEvent event, ChannelRepository channelRepo) {
-    this.event = event;
+  /**
+   * @param request The discord request dispatched to this command
+   * @param channelRepo  The channel repository used to communicate with the database
+   */
+  @Populate
+  public ListChannels(DiscordRequest request, ChannelRepository channelRepo) {
+    this.event = request.getEvent();
     this.channelRepo = channelRepo;
   }
 
   /**
    * Command execution method held by Disparse
-   * 
-   * @param event The message event from discord that triggered the command
-   * @param repo  The channel repository used to communicate with the database
    */
   @CommandHandler(commandName = "channels", description = "Lists all channels registered",
       roles = "staff")
-  public static void executeList(MessageReceivedEvent event, ChannelRepository repo) {
-    new ListChannels(event, repo).execute();
+  public void executeList() {
+    this.execute();
   }
 
   /**
@@ -43,7 +48,7 @@ public class ListChannels {
   /**
    * Create a {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbed} to display all the
    * channels and their respective permissions.
-   * 
+   *
    * @param channels the list of channels retrieved from the database
    * @return a {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbed}
    */

--- a/src/main/java/uk/co/markg/bertrand/command/OptOut.java
+++ b/src/main/java/uk/co/markg/bertrand/command/OptOut.java
@@ -1,6 +1,8 @@
 package uk.co.markg.bertrand.command;
 
+import disparse.discord.jda.DiscordRequest;
 import disparse.parser.reflection.CommandHandler;
+import disparse.parser.reflection.Populate;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import uk.co.markg.bertrand.database.UserRepository;
 import uk.co.markg.bertrand.markov.MarkovSender;
@@ -10,20 +12,24 @@ public class OptOut {
   private MessageReceivedEvent event;
   private UserRepository userRepo;
 
-  public OptOut(MessageReceivedEvent event, UserRepository userRepo) {
-    this.event = event;
+  /**
+   * Command execution method held by Disparse
+   *
+   * @param request  The discord request dispatched to this command
+   * @param userRepo The user repository used to communicate with the database
+   */
+  @Populate
+  public OptOut(DiscordRequest request, UserRepository userRepo) {
+    this.event = request.getEvent();
     this.userRepo = userRepo;
   }
 
   /**
    * Command execution method held by Disparse
-   * 
-   * @param event    The message event from discord that triggered the command
-   * @param userRepo The user repository used to communicate with the database
    */
   @CommandHandler(commandName = "opt-out", description = "Opt-out for all messages to be removed.")
-  public static void execute(MessageReceivedEvent event, UserRepository userRepo) {
-    new OptOut(event, userRepo).execute();
+  public void optOutCommand() {
+    this.execute();
   }
 
   /**
@@ -41,7 +47,7 @@ public class OptOut {
 
   /**
    * OptOut a user by deleting them and their related data from the database.
-   * 
+   *
    * @param userid the user to delete
    */
   private void optOutUser(long userid) {

--- a/src/main/java/uk/co/markg/bertrand/command/RemoveChannels.java
+++ b/src/main/java/uk/co/markg/bertrand/command/RemoveChannels.java
@@ -2,7 +2,10 @@ package uk.co.markg.bertrand.command;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import disparse.discord.jda.DiscordRequest;
 import disparse.parser.reflection.CommandHandler;
+import disparse.parser.reflection.Populate;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import uk.co.markg.bertrand.database.ChannelRepository;
 
@@ -12,25 +15,27 @@ public class RemoveChannels {
   private ChannelRepository channelRepo;
   private List<String> args;
 
-  public RemoveChannels(MessageReceivedEvent event, ChannelRepository channelRepo,
-      List<String> args) {
-    this.event = event;
+  /**
+   * Command execution method held by Disparse
+   *
+   * @param request       The discord request dispatched to this command
+   * @param channelRepo   The channel repository used to communicate with the database
+   */
+  @Populate
+  public RemoveChannels(DiscordRequest request, ChannelRepository channelRepo) {
+    this.event = request.getEvent();
     this.channelRepo = channelRepo;
-    this.args = args;
+    this.args = request.getArgs();
   }
 
   /**
    * Command execution method held by Disparse
-   * 
-   * @param event The message event from discord that triggered the command
-   * @param repo  The channel repository used to communicate with the database
    */
   @CommandHandler(commandName = "channels.remove",
       description = "Remove channels from the database. All related messages are also removed.",
       roles = "staff")
-  public static void executeRemove(MessageReceivedEvent event, ChannelRepository repo,
-      List<String> args) {
-    new RemoveChannels(event, repo, args).execute();
+  public void executeRemove() {
+    this.execute();
   }
 
   private void execute() {
@@ -40,7 +45,7 @@ public class RemoveChannels {
 
   /**
    * Removes existing channels from the database and any messages saved from those channels
-   * 
+   *
    * @return A string indicating success or failure. Failure message includes a list of channels
    *         that could not be removed from the database
    */

--- a/src/main/java/uk/co/markg/bertrand/command/markov/MarkovAll.java
+++ b/src/main/java/uk/co/markg/bertrand/command/markov/MarkovAll.java
@@ -1,5 +1,6 @@
 package uk.co.markg.bertrand.command.markov;
 
+import disparse.discord.jda.DiscordRequest;
 import disparse.parser.reflection.CommandHandler;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import uk.co.markg.bertrand.database.ChannelRepository;
@@ -15,8 +16,9 @@ public class MarkovAll {
 
   @CommandHandler(commandName = "all",
       description = "Generate a random number of sentences from all opted in user messages!")
-  public static void execute(MessageReceivedEvent event, ChannelRepository channelRepo,
-      UserRepository userRepo) {
+  public static void execute(DiscordRequest request, ChannelRepository channelRepo,
+                             UserRepository userRepo) {
+    MessageReceivedEvent event = request.getEvent();
     if (!channelRepo.hasWritePermission(event.getChannel().getIdLong())) {
       return;
     }

--- a/src/main/java/uk/co/markg/bertrand/command/markov/MarkovRand.java
+++ b/src/main/java/uk/co/markg/bertrand/command/markov/MarkovRand.java
@@ -1,6 +1,8 @@
 package uk.co.markg.bertrand.command.markov;
 
 import java.util.concurrent.ThreadLocalRandom;
+
+import disparse.discord.jda.DiscordRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import disparse.parser.reflection.CommandHandler;
@@ -15,8 +17,9 @@ public class MarkovRand {
 
   @CommandHandler(commandName = "rand",
       description = "Generate a random number of sentences from random user's messages!")
-  public static void execute(MessageReceivedEvent event, ChannelRepository channelRepo,
-      UserRepository userRepo) {
+  public static void execute(DiscordRequest request, ChannelRepository channelRepo,
+                             UserRepository userRepo) {
+    MessageReceivedEvent event = request.getEvent();
     if (!channelRepo.hasWritePermission(event.getChannel().getIdLong())) {
       return;
     }

--- a/src/main/java/uk/co/markg/bertrand/command/markov/MarkovSelf.java
+++ b/src/main/java/uk/co/markg/bertrand/command/markov/MarkovSelf.java
@@ -1,5 +1,6 @@
 package uk.co.markg.bertrand.command.markov;
 
+import disparse.discord.jda.DiscordRequest;
 import disparse.parser.reflection.CommandHandler;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import uk.co.markg.bertrand.database.ChannelRepository;
@@ -11,8 +12,9 @@ public class MarkovSelf {
 
   @CommandHandler(commandName = "self",
       description = "Generate a random number of sentences from your own messages!")
-  public static void execute(MessageReceivedEvent event, ChannelRepository channelRepo,
-      UserRepository userRepo) {
+  public static void execute(DiscordRequest request, ChannelRepository channelRepo,
+                             UserRepository userRepo) {
+    MessageReceivedEvent event = request.getEvent();
     if (!channelRepo.hasWritePermission(event.getChannel().getIdLong())) {
       return;
     }


### PR DESCRIPTION
All commands using `MessageReceivedEvent` as a parameter will no longer work as of Disparse `0.1+` therefore updating all commands to use `DiscordRequest` / `DiscordResponse` is the only way to get event / arguments injected.

Some command handlers were static, immediately creating a new object and calling execute on it.  Using constructor injection with the new `@Populate` annotation from Disparse allows the command handler to be non-static and to automatically have the needed fields populated.

Some commands manually sent an embed message to the event with a call to `EmbedBuilder#build`.  This still definitely works, but in the very simple case where an embed is always returned changing to use `DiscordResponse#of` makes it a bit simpler and does the same thing.