### PR TITLE
[docker] Add minimal docker compose for launching postgres

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  postgres:
+    build: postgres
+    restart: always
+    container_name: mimic_postgres
+    ports:
+    - "5432:5432"
+    volumes:
+      - mimic_postgres:/var/lib/postgres
+    environment:
+      - POSTGRES_USER=${B_USER}
+      - POSTGRES_PASSWORD=${B_PASS}
+
+volumes:
+  mimic_postgres:
+    driver: local

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:12
+
+CMD ["postgres"]


### PR DESCRIPTION
Add a basic docker configuration that allows a more streamlined dev process for new contributors.

Relies on the same environment variables that were already used in the project `B_PASS` and `B_USER`.  `docker-compose up` will let the container to spin up with postgres.